### PR TITLE
fix bug in bb_only bwa

### DIFF
--- a/tidehunter_only_sing.smk
+++ b/tidehunter_only_sing.smk
@@ -24,7 +24,7 @@ rule all:
 # stats mapped all consensus bam file
         expand("output/{SUP_SAMPLE}/07_stats_done/samtools_stats_no_bb_not_fl.done", SUP_SAMPLE=SUP_SAMPLES),
 # map fasta file to bb only. (check which reads contain backbones)
-        expand("output/{SUP_SAMPLE}/07_stats_done/bwa_wrapper_bb_only.done", SUP_SAMPLE=SUP_SAMPLES),
+        expand("output/{SUP_SAMPLE}/07_stats_done/filter_bb_only.done", SUP_SAMPLE=SUP_SAMPLES),
 localrules: all, get_timestamp, gz_fastq_get_fasta, fastq_get_fasta, aggregate_tide 
 
 # check if use singularity image for Tidehunter or not. Please specify in configfiles.
@@ -346,7 +346,10 @@ rule samtools_view_bb_only:
     input:
         sorted = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only_unfiltered.sorted.bam"
     output:
-        view = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only.sorted.bam"
+        view = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only.sorted.bam",
+        done = touch("output/{SUP_SAMPLE}/07_stats_done/filter_bb_only.done")
+    conda:
+        "envs/bt.yaml"
     shell:
         "samtools view -b -F 4 {input.sorted} > {output.view}"
 

--- a/tidehunter_only_sing.smk
+++ b/tidehunter_only_sing.smk
@@ -325,13 +325,13 @@ rule bwa_wrapper_bb_only:
         ref_built = "output/{SUP_SAMPLE}/04_done/gen_bb_ref.done",
         reads="output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_tide_consensus_trimmed.fasta",
     output:
-        bam = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only.sorted.bam",
+        bam = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only_unfiltered.sorted.bam",
         done = touch("output/{SUP_SAMPLE}/07_stats_done/bwa_wrapper_bb_only.done")
     log:
         "log/{SUP_SAMPLE}/{SUP_SAMPLE}_wrapper_bwa_bb_only.log"
     params:
         index=config['backbone_fa'],
-        extra=r"-F 4 -R '@RG\tID:{SUP_SAMPLE}\tSM:{SUP_SAMPLE}'",
+        extra=r"-R '@RG\tID:{SUP_SAMPLE}\tSM:{SUP_SAMPLE}'",
         sort="samtools",             # Can be 'none', 'samtools' or 'picard'.
         sort_order="coordinate",  # Can be 'queryname' or 'coordinate'.
         sort_extra="-l 9"            # Extra args for samtools/picard.
@@ -341,6 +341,15 @@ rule bwa_wrapper_bb_only:
         runtime=lambda wildcards, attempt, input: ( attempt * 4)
     wrapper:
         "0.68.0/bio/bwa/mem"
+
+rule samtools_view_bb_only:
+    input:
+        sorted = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only_unfiltered.sorted.bam"
+    output:
+        view = "output/{SUP_SAMPLE}/05_aggregated/{SUP_SAMPLE}_bb_only.sorted.bam"
+    shell:
+        "samtools view -b -F 4 {input.sorted} > {output.view}"
+
 
 
 rule bwa_wrapper_tide_full_length:


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Wrong parameter -F was given to bwa.
Now new rule after bwa_wrapper_bb_only is added to filter out reads that only mapped to bb. The final output file for this is the same "TEST40_bb_only.sorted.bam"

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. snakemake --snakefile tidehunter_only_sing.smk --configfile configfiles/config-TESTGITHUB.yaml  --cores 4 --use-conda
2. ls output/TEST40/05_aggregated/TEST40_bb_only.sorted.bam
exist
